### PR TITLE
Fix/clone stream

### DIFF
--- a/src/MsSqlFsBlobProvider/SqlFileStreamBlobMetaDataProvider.cs
+++ b/src/MsSqlFsBlobProvider/SqlFileStreamBlobMetaDataProvider.cs
@@ -121,7 +121,6 @@ FROM  dbo.Files WHERE FileId = @FileId
                     blobProviderData = new SqlFileStreamBlobProviderData {FileStreamData = fsData};
                     // Name of the SqlFS and BuiltIn are the same: null
                     //   so currently need to change to the SqlFS provider.
-                    //provider = BlobStorageBase.GetProvider(length);
                     provider = new SqlFileStreamBlobProvider();
                 }
                 else

--- a/src/MsSqlFsBlobProvider/SqlFileStreamBlobMetaDataProvider.cs
+++ b/src/MsSqlFsBlobProvider/SqlFileStreamBlobMetaDataProvider.cs
@@ -508,15 +508,10 @@ SELECT @FileId, FileStream.PathName(), GET_FILESTREAM_TRANSACTION_CONTEXT() FROM
                     var providerName = reader.GetSafeString(3);
                     var providerTextData = reader.GetSafeString(4);
 
-                    byte[] rawData;
-                    if (reader.IsDBNull(5))
-                        rawData = null;
-                    else
-                        rawData = (byte[])reader.GetValue(5);
-
+                    byte[] rawData = null;
 
                     SqlFileStreamData fileStreamData = null;
-                    var useFileStream = reader.GetInt32(6) == 1;
+                    var useFileStream = providerName == null && reader.GetInt32(6) == 1;
                     if (useFileStream)
                     {
                         // fill Filestream info if we really need it
@@ -543,6 +538,10 @@ SELECT @FileId, FileStream.PathName(), GET_FILESTREAM_TRANSACTION_CONTEXT() FROM
                         context.BlobProviderData = new BuiltinBlobProviderData();
                     else if (provider is SqlFileStreamBlobProvider)
                         context.BlobProviderData = new SqlFileStreamBlobProviderData { FileStreamData = fileStreamData };
+
+                    if (IsBuiltInOrSqlFileStreamProvider(provider))
+                        if (!reader.IsDBNull(5))
+                            rawData = (byte[])reader.GetValue(5);
 
                     return new BinaryCacheEntity
                     {


### PR DESCRIPTION
Please check the changes.
- **UpdateBinaryProperty** methods: always create new rows in the Files table/collection.
- **LoadBinaryCacheEntity** method: no built-in stream used if the provider is external.

These changes are connected to other modifications of the following repositories:
- **sn-integrationtests**:  https://github.com/SenseNet/sn-integrationtests/tree/fix/clone-stream
- **sensenet**: https://github.com/SenseNet/sensenet/tree/fix/clone-stream